### PR TITLE
Bump minimum iOS version to 12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,24 @@ jobs:
   xcode-build:
     name: Xcode Build
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        platform: ['iOS_13', 'iOS_12']
+      fail-fast: false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Select Xcode Version
+      - name: Select Xcode Version (12.3)
+        run: sudo xcode-select --switch /Applications/Xcode_12.3.app/Contents/Developer
+        if: matrix.platform == 'iOS_13'
+      - name: Select Xcode Version (11.6)
         run: sudo xcode-select --switch /Applications/Xcode_11.6.app/Contents/Developer
+        if: matrix.platform == 'iOS_13'
+      - name: Select Xcode Version (10.3)
+        run: sudo xcode-select --switch /Applications/Xcode_10.3.app/Contents/Developer
+        if: matrix.platform == 'iOS_12'
       - name: Build and Test
-        run: |
-          xcrun xcodebuild \
-            -project Paralayout.xcodeproj \
-            -scheme "ParalayoutStudio" \
-            -sdk iphonesimulator \
-            -destination "platform=iOS Simulator,OS=13.6,name=iPhone 11 Pro" \
-            -configuration Debug \
-            -PBXBuildsContinueAfterErrors=0 \
-            ACTIVE_ARCH_ONLY=0 \
-            build test
+        run: Scripts/build.swift xcode ${{ matrix.platform }} `which xcpretty`
   pod-lint:
     name: Lint Pod
     runs-on: macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Select Xcode Version (12.3)
-        run: sudo xcode-select --switch /Applications/Xcode_12.3.app/Contents/Developer
+      - name: Select Xcode Version (12.2)
+        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
         if: matrix.platform == 'iOS_13'
       - name: Select Xcode Version (11.6)
         run: sudo xcode-select --switch /Applications/Xcode_11.6.app/Contents/Developer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        platform: ['iOS_13', 'iOS_12']
+        platform: ['iOS_14', 'iOS_13', 'iOS_12']
       fail-fast: false
     steps:
       - name: Checkout Repo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: objective-c
-osx_image: xcode10.1
-before_script:
-    - bundle install
-    - xcodebuild -list
-script:
-    - xcodebuild -project Paralayout.xcodeproj -scheme "ParalayoutStudio" -sdk iphonesimulator -destination "platform=iOS Simulator,OS=10.2,name=iPhone 7" -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
-    - pod lib lint --verbose --fail-fast

--- a/Paralayout.podspec
+++ b/Paralayout.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.authors  = 'Square'
   s.source   = { :git => 'https://github.com/square/Paralayout.git', :tag => s.version }
   s.source_files = 'Paralayout/*.{swift}'
-  s.ios.deployment_target = '9.0'
-  s.swift_version = '4.2'
+  s.ios.deployment_target = '12.0'
+  s.swift_version = '5.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'ParalayoutTests/*{.swift}'

--- a/Paralayout.xcodeproj/project.pbxproj
+++ b/Paralayout.xcodeproj/project.pbxproj
@@ -285,34 +285,33 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1220;
 				ORGANIZATIONNAME = "Square, Inc.";
 				TargetAttributes = {
 					D049FD7F1ECA7BC4009BEF98 = {
 						CreatedOnToolsVersion = 8.3.2;
 						DevelopmentTeam = 2F6H5NK8EM;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1220;
 						ProvisioningStyle = Automatic;
 					};
 					D0624F701EDF8C3F00076663 = {
 						CreatedOnToolsVersion = 8.3.2;
 						DevelopmentTeam = 2F6H5NK8EM;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1220;
 						ProvisioningStyle = Automatic;
 					};
 					D0624FC31EDFA1AE00076663 = {
 						CreatedOnToolsVersion = 8.3.2;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1220;
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = D049FD7B1ECA7BC4009BEF98 /* Build configuration list for PBXProject "Paralayout" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -457,6 +456,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -482,7 +482,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -518,6 +518,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -537,7 +538,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -553,12 +554,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 2F6H5NK8EM;
 				INFOPLIST_FILE = "$(SRCROOT)/ParalayoutStudio/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.square.ParalayoutStudio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -570,12 +571,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 2F6H5NK8EM;
 				INFOPLIST_FILE = "$(SRCROOT)/ParalayoutStudio/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.square.ParalayoutStudio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -592,13 +593,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Paralayout/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.square.Paralayout;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -617,13 +618,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Paralayout/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.square.Paralayout;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -638,7 +639,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.square.ParalayoutTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -650,7 +651,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.square.ParalayoutTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Paralayout.xcodeproj/xcshareddata/xcschemes/Paralayout.xcscheme
+++ b/Paralayout.xcodeproj/xcshareddata/xcschemes/Paralayout.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Paralayout.xcodeproj/xcshareddata/xcschemes/ParalayoutStudio.xcscheme
+++ b/Paralayout.xcodeproj/xcshareddata/xcschemes/ParalayoutStudio.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Paralayout/Label.swift
+++ b/Paralayout/Label.swift
@@ -407,13 +407,20 @@ public final class Label : UILabel {
             textBounds.origin.x = textBounds.maxX - bestWidth
             
         case .natural, .justified:
-            switch UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) {
+            let layoutDirection = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
+            switch layoutDirection {
             case .leftToRight:
                 break // No-op. Text bounds are already left-alignment.
                 
             case .rightToLeft:
                 textBounds.origin.x = textBounds.maxX - bestWidth
+
+            @unknown default:
+                fatalError("Unknown user interface layout direction: \(layoutDirection)")
             }
+
+        @unknown default:
+            fatalError("Unknown text alignment: \(textAlignment)")
         }
         
         textBounds.size.width = bestWidth

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Paralayout is a set of simple, useful, and straightforward utilities that enable
 
 Integrating Paralayout into your iOS project via [CocoaPods](http://cocoapods.org) is simple:
 
-```
-platform :ios, '9.0'
+```ruby
 pod 'Paralayout'
 ```
 
@@ -156,8 +155,9 @@ Fixing layout issues is as simple as using the Xcode debugger. Remember that on 
 
 ## Requirements
 
-* Xcode 10 / Swift 4.2
-* iOS 9.0 or later
+* iOS 12.0 or later
+* Xcode 10.0 or later
+* Swift 5.0
 
 
 ## Contributing

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -1,0 +1,180 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+// Usage: build.swift xcode <platform> [<path_to_xcpretty>]
+
+func execute(commandPath: String, arguments: [String], pipedTo pipeProcess: Process? = nil) throws {
+	let task = Process()
+	task.launchPath = commandPath
+	task.arguments = arguments
+
+	let argumentsString = arguments
+		.map { argument in
+			if argument.contains(" ") {
+				return "\"\(argument)\""
+			} else {
+				return argument
+			}
+		}
+		.joined(separator: " ")
+
+	if let pipeProcess = pipeProcess, let pipePath = pipeProcess.launchPath {
+		let pipe = Pipe()
+		task.standardOutput = pipe
+		pipeProcess.standardInput = pipe
+
+		print("Launching command: \(commandPath) \(argumentsString) | \(pipePath)")
+
+	} else {
+		print("Launching command: \(commandPath) \(argumentsString)")
+	}
+
+	task.launch()
+
+	pipeProcess?.launch()
+
+	task.waitUntilExit()
+
+	guard task.terminationStatus == 0 else {
+		throw TaskError.code(task.terminationStatus)
+	}
+}
+
+enum TaskError: Error {
+	case code(Int32)
+}
+
+enum Platform: String, CustomStringConvertible {
+	case iOS_14
+	case iOS_13
+	case iOS_12
+
+	var destination: String {
+		switch self {
+		case .iOS_14:
+			return "platform=iOS Simulator,OS=14.3,name=iPhone 12 Pro"
+		case .iOS_13:
+			return "platform=iOS Simulator,OS=13.6,name=iPhone 11 Pro"
+		case .iOS_12:
+			return "platform=iOS Simulator,OS=12.4,name=iPhone Xs"
+		}
+	}
+
+	var derivedDataPath: String {
+		return ".build/derivedData/\(rawValue)"
+	}
+
+	var description: String {
+		return rawValue
+	}
+}
+
+enum Task: String, CustomStringConvertible {
+	case xcode
+
+	var workspace: String? {
+		switch self {
+		case .xcode:
+			return nil
+		}
+	}
+
+	var project: String? {
+		switch self {
+		case .xcode:
+			return "Paralayout.xcodeproj"
+		}
+	}
+
+	var scheme: String {
+		switch self {
+		case .xcode:
+			return "ParalayoutStudio"
+		}
+	}
+
+	var configuration: String {
+		switch self {
+		case .xcode:
+			return "Debug"
+		}
+	}
+
+	var shouldGenerateXcodeProject: Bool {
+		switch self {
+		case .xcode:
+			return false
+		}
+	}
+
+	var shouldRunTests: Bool {
+		switch self {
+		case .xcode:
+			return true
+		}
+	}
+
+	var description: String {
+		return rawValue
+	}
+}
+
+guard CommandLine.arguments.count > 2 else {
+	print("Usage: build.swift xcode <platform>")
+	throw TaskError.code(1)
+}
+
+let rawTask = CommandLine.arguments[1]
+let rawPlatform = CommandLine.arguments[2]
+
+guard let task = Task(rawValue: rawTask) else {
+	print("Received unknown task \"\(rawTask)\"")
+	throw TaskError.code(1)
+}
+
+if task.shouldGenerateXcodeProject {
+	try execute(commandPath: "/usr/bin/swift", arguments: ["package", "generate-xcodeproj", "--output=generated/"])
+}
+
+guard let platform = Platform(rawValue: rawPlatform) else {
+	print("Received unknown platform \"\(rawPlatform)\"")
+	throw TaskError.code(1)
+}
+
+var xcodeBuildArguments: [String] = []
+
+if let workspace = task.workspace {
+	xcodeBuildArguments.append("-workspace")
+	xcodeBuildArguments.append(workspace)
+} else if let project = task.project {
+	xcodeBuildArguments.append("-project")
+	xcodeBuildArguments.append(project)
+}
+
+xcodeBuildArguments.append(
+	contentsOf: [
+		"-scheme", task.scheme,
+		"-sdk", "iphonesimulator",
+		"-PBXBuildsContinueAfterErrors=0",
+		"-destination", platform.destination,
+		"-configuration", task.configuration,
+		"-derivedDataPath", platform.derivedDataPath,
+		"ONLY_ACTIVE_ARCH=NO",
+		"build"
+	]
+)
+
+if task.shouldRunTests {
+	xcodeBuildArguments.append("test")
+}
+
+let xcpretty: Process?
+if CommandLine.arguments.count > 3 {
+	xcpretty = .init()
+	xcpretty?.launchPath = CommandLine.arguments[3]
+} else {
+	xcpretty = nil
+}
+
+try execute(commandPath: "/usr/bin/xcodebuild", arguments: xcodeBuildArguments, pipedTo: xcpretty)

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -53,7 +53,7 @@ enum Platform: String, CustomStringConvertible {
 	var destination: String {
 		switch self {
 		case .iOS_14:
-			return "platform=iOS Simulator,OS=14.3,name=iPhone 12 Pro"
+			return "platform=iOS Simulator,OS=14.2,name=iPhone 12 Pro"
 		case .iOS_13:
 			return "platform=iOS Simulator,OS=13.6,name=iPhone 11 Pro"
 		case .iOS_12:


### PR DESCRIPTION
* Bumps the minimum iOS version to 12.0
* Bumps the Swift version to 5.0
* Adopts recommended Xcode settings to clear out warnings
* Updates the CI configuration to run a larger matrix on GitHub Actions, replacing Travis CI completely, and using a cleaner script that will make future CI changes easier to deal with