### PR TITLE
Size views by their bounds instead of frame

### DIFF
--- a/Paralayout/UIViewAdditions_Sizing.swift
+++ b/Paralayout/UIViewAdditions_Sizing.swift
@@ -116,11 +116,22 @@ extension UIView {
         return sizeThatFits(CGSize(width: width, height: height), constraints: constraints)
     }
 
-    /// Resize the view to fit a given size, with constraints applied.
-    /// - parameter sizeToFit: The size to fit, typically the `superview.bounds` or smaller.
-    /// - parameter constraints: Limits on the size to actually set (optional, defaults to `.none`).
+    /// Set the "ideal" size for the receiver within the available space (the `sizeToFit`), applying the provided
+    /// constraints. The view's final size will never be less than zero in either dimension.
+    ///
+    /// This method updates the size of the receiver's `bounds`, and is therefore `center`-preserving. Note that this
+    /// means the receiver's `frame.origin` may change as a result of calling this method.
+    ///
+    /// - parameter sizeToFit: The size within which to fit, passed through to `sizeThatFits(_:)`.
+    /// - parameter constraints: Limits on the size to actually set. Defaults to `.none`.
     public func sizeToFit(_ sizeToFit: CGSize, constraints: SizingConstraints = .none) {
-        frame.size = sizeThatFits(sizeToFit, constraints: constraints)
+        let sizeThatFits = self.sizeThatFits(sizeToFit, constraints: constraints)
+
+        // Setting the bound's width or height to a negative value will result in the origin being shifted by that
+        // amount (and the size parameter inverted). This is almost never the behavior we want here, and is difficult to
+        // undo later since it requires explicitly setting the bound's origin.
+        bounds.size.width = max(sizeThatFits.width, 0)
+        bounds.size.height = max(sizeThatFits.height, 0)
     }
 
     /// Resize the view to fit a given width.

--- a/Paralayout/UIViewAdditions_Sizing.swift
+++ b/Paralayout/UIViewAdditions_Sizing.swift
@@ -130,8 +130,10 @@ extension UIView {
         // Setting the bound's width or height to a negative value will result in the origin being shifted by that
         // amount (and the size parameter inverted). This is almost never the behavior we want here, and is difficult to
         // undo later since it requires explicitly setting the bound's origin.
-        bounds.size.width = max(sizeThatFits.width, 0)
-        bounds.size.height = max(sizeThatFits.height, 0)
+        bounds.size = CGSize(
+            width: max(sizeThatFits.width, 0),
+            height: max(sizeThatFits.height, 0)
+        )
     }
 
     /// Resize the view to fit a given width.

--- a/ParalayoutTests/UIViewSizingTests.swift
+++ b/ParalayoutTests/UIViewSizingTests.swift
@@ -107,6 +107,30 @@ final class UIViewSizingTests: XCTestCase {
         )
     }
 
+    func testSizeToFitWithTransform() {
+        let testView = TestView(sizeThatFits: .init(width: 300, height: 200))
+        testView.transform = .init(scaleX: 2, y: 2)
+        testView.sizeToFit(.init(width: 100, height: 50), constraints: .maxSize)
+
+        // The constrained size should be applied to the untransformed frame of the view.
+        XCTAssertEqual(testView.bounds.size, .init(width: 100, height: 50))
+        XCTAssertEqual(testView.frame.size, .init(width: 200, height: 100))
+    }
+
+    func testSizeToFitWithNegativeWidth() {
+        let testView = TestView(sizeThatFits: .init(width: -50, height: 200))
+        testView.sizeToFit(.init(width: 100, height: 50))
+
+        XCTAssertEqual(testView.bounds.size, .init(width: 0, height: 200))
+    }
+
+    func testSizeToFitWithNegativeHeight() {
+        let testView = TestView(sizeThatFits: .init(width: 200, height: -50))
+        testView.sizeToFit(.init(width: 100, height: 50))
+
+        XCTAssertEqual(testView.bounds.size, .init(width: 200, height: 0))
+    }
+
 }
 
 // MARK: -


### PR DESCRIPTION
The primary behavior difference here affects views that have a non-identity transform applied.

There is also a slight behavior difference in that sizing views is now `center`-preserving, rather than `origin`-preserving. This shouldn't affect most idiomatic Paralayout code, since the recommendation is to size views, then align them.

This addresses part of #49.