### PR TITLE
Use `UIView.center` instead of `CALayer.position` for alignment

### DIFF
--- a/Paralayout/UIView+Frame.swift
+++ b/Paralayout/UIView+Frame.swift
@@ -37,7 +37,7 @@ extension UIView {
         }
         set {
             bounds.size = newValue.size
-            layer.position = CGPoint(
+            center = CGPoint(
                 x: newValue.minX + newValue.width * layer.anchorPoint.x,
                 y: newValue.minY + newValue.height * layer.anchorPoint.y
             )


### PR DESCRIPTION
Paralayout uses `UIView.bounds` and `CALayer.position` for alignment to avoid errors when `UIView.frame` is undefined because it has a non-identity `transform` applied to it. Unfortunately, CALayer and UIKit have a bug where `safeAreaInsets` are not correctly updated after setting `CALayer.position` for a layer that backs a `UIView`.

This can be rectified by setting `UIView.center` instead, which is documented to be safe even when `frame` is not.