### PR TITLE
Correctly account for zero-width spacers in implied distribution

### DIFF
--- a/Paralayout/ViewDistributionItem.swift
+++ b/Paralayout/ViewDistributionItem.swift
@@ -66,6 +66,7 @@ public enum ViewDistributionItem: ViewDistributionSpecifying, Sendable {
         var distributionItems = [ViewDistributionItem]()
         var totalViewSize: CGFloat = 0
         var totalFixedSpace: CGFloat = 0
+        var hasFixedSpacers: Bool = false
         var totalFlexibleSpace: CGFloat = 0
 
         var subviewsToDistribute = Set<UIView>()
@@ -92,6 +93,7 @@ public enum ViewDistributionItem: ViewDistributionSpecifying, Sendable {
 
             case .fixed:
                 totalFixedSpace += layoutSize
+                hasFixedSpacers = true
 
             case .flexible:
                 totalFlexibleSpace += layoutSize
@@ -107,7 +109,7 @@ public enum ViewDistributionItem: ViewDistributionSpecifying, Sendable {
 
         // Insert flexible space if necessary.
         if totalFlexibleSpace == 0 {
-            if totalFixedSpace == 0 {
+            if !hasFixedSpacers {
                 // No spacers at all: insert `1.flexible` between all items.
                 for i in 0 ..< (distributionItems.count + 1) {
                     distributionItems.insert(1.flexible, at: i * 2)

--- a/ParalayoutTests/DistributionTests.swift
+++ b/ParalayoutTests/DistributionTests.swift
@@ -214,4 +214,26 @@ final class DistributionTests: XCTestCase {
         }
     }
 
+    // MARK: - Tests - Spacers
+
+    @MainActor
+    func testZeroSizeFixedSpacer() {
+        let container = UIView(frame: .init(x: 0, y: 0, width: 100, height: 400))
+        container.semanticContentAttribute = .forceRightToLeft
+
+        let firstSubview = UIView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        container.addSubview(firstSubview)
+        let secondSubview = UIView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        container.addSubview(secondSubview)
+
+        container.applyVerticalSubviewDistribution {
+            firstSubview
+            0.fixed
+            secondSubview
+        }
+
+        XCTAssertEqual(firstSubview.frame, .init(x: 0, y: 100, width: 100, height: 100))
+        XCTAssertEqual(secondSubview.frame, .init(x: 0, y: 200, width: 100, height: 100))
+    }
+
 }


### PR DESCRIPTION
Currently the implied distribution does not behave as documented in cases where the fixed spacers sum to zero (either by using zero-size spacers or by combining positive- and negative-sized spacers). This updates the logic to correctly identify the use of _any_ fixed spacer.

Resolves #126