### PR TITLE
Replace assertions in slice method with alert func

### DIFF
--- a/Paralayout/ParalayoutLog.swift
+++ b/Paralayout/ParalayoutLog.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright © 2024 Block, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import os
+
+nonisolated
+internal let ParalayoutLog = OSLog(subsystem: "com.squareup.Paralayout", category: "layout")

--- a/Paralayout/UIView+Alignment.swift
+++ b/Paralayout/UIView+Alignment.swift
@@ -170,8 +170,6 @@ extension AlignmentContext {
 
 // MARK: -
 
-@MainActor
-private let ParalayoutLog = OSLog(subsystem: "com.squareup.Paralayout", category: "layout")
 
 /// Triggered when an alignment method is called that uses mismatched position types, i.e. aligning a view's leading or
 /// trailing edge to another view's left or right edge, or vice versa. This type of mismatch is likely to look correct


### PR DESCRIPTION
There are some valid use cases where you want to be able to slice more than the available width/height, such as when your content has a minimum size and your sizing rules allow for content to extend beyond the bounds if you view is sized beneath its ideal size. This replaces the assertions in the `slice(...)` method with alert functions consumers can place breakpoints for, following the pattern we use for view alignment issues.

Resolves #128