### PR TITLE
Adopt Swift 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Lint Podspec
         run: bundle exec pod lib lint --verbose --fail-fast --swift-version=6.0
   spm-5:
-    name: SPM Swift 5 Build
+    name: SPM Build
     runs-on: macOS-14
     strategy:
       matrix:
@@ -70,7 +70,7 @@ jobs:
       - name: Build
         run: Scripts/build.swift spm ${{ matrix.platform }} `which xcpretty`
   spm-6:
-    name: SPM Swift 6 Build
+    name: SPM Build
     runs-on: macOS-16
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_15.4.app/Contents/Developer
       - name: Lint Podspec
         run: bundle exec pod lib lint --verbose --fail-fast
-  spm:
-    name: SPM Build
+  spm-5:
+    name: SPM Swift 5 Build
     runs-on: macOS-14
     strategy:
       matrix:
@@ -67,6 +67,24 @@ jobs:
         uses: actions/checkout@v4
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.4.app/Contents/Developer
+      - name: Build
+        run: Scripts/build.swift spm ${{ matrix.platform }} `which xcpretty`
+  spm-6:
+    name: SPM Swift 6 Build
+    runs-on: macOS-16
+    strategy:
+      matrix:
+        platform: ['iOS_18']
+      fail-fast: false
+    steps:
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.4'
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
       - name: Build
         run: Scripts/build.swift spm ${{ matrix.platform }} `which xcpretty`
   bazel:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           path: .build/derivedData/**/Logs/Test/*.xcresult
   pod-lint:
     name: Lint Pod
-    runs-on: macOS-14
+    runs-on: macOS-15
     steps:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -48,9 +48,9 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.4.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
       - name: Lint Podspec
-        run: bundle exec pod lib lint --verbose --fail-fast
+        run: bundle exec pod lib lint --verbose --fail-fast --swift-version=6.0
   spm-5:
     name: SPM Swift 5 Build
     runs-on: macOS-14

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:5.9
 
 //
 //  Copyright 2020 Square Inc.
@@ -35,16 +35,14 @@ let package = Package(
 			dependencies: [],
 			path: "Paralayout",
 			swiftSettings: [
-                .swiftLanguageMode(.v6),
+				.enableExperimentalFeature("StrictConcurrency")
 			]
 		),
 		.testTarget(
 			name: "ParalayoutTests",
 			dependencies: ["Paralayout"],
-			path: "ParalayoutTests",
-            swiftSettings: [
-                .swiftLanguageMode(.v6),
-            ]
+			path: "ParalayoutTests"
 		),
-	]
+	],
+	swiftLanguageVersions: [.v5]
 )

--- a/Paralayout.podspec
+++ b/Paralayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Paralayout'
-  s.version  = '1.1.0'
+  s.version  = '2.0.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Paralayout is a simple set of assistive UI layout utilities. Size and position your UI with pixel-perfect precision. Design will love you!'
   s.homepage = 'https://github.com/square/Paralayout'
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/square/Paralayout.git', :tag => s.version }
   s.source_files = 'Paralayout/*.{swift}'
   s.ios.deployment_target = '13.0'
-  s.swift_version = '5.9'
+  s.swift_version = '6.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'ParalayoutTests/*{.swift}'

--- a/Paralayout.podspec
+++ b/Paralayout.podspec
@@ -8,7 +8,6 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/square/Paralayout.git', :tag => s.version }
   s.source_files = 'Paralayout/*.{swift}'
   s.ios.deployment_target = '13.0'
-  s.swift_version = '6.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'ParalayoutTests/*{.swift}'

--- a/ParalayoutTests/UIViewFrameTests.swift
+++ b/ParalayoutTests/UIViewFrameTests.swift
@@ -215,7 +215,7 @@ final class UIViewFrameTests: XCTestCase {
     // MARK: - Private Helper Methods
 
     @MainActor
-    func assertUntransformedFrameIsAccurate(for view: UIView, file: StaticString = #file, line: UInt = #line) {
+    func assertUntransformedFrameIsAccurate(for view: UIView, file: StaticString = #filePath, line: UInt = #line) {
         let actualValue = view.untransformedFrame
 
         let originalTransform = view.layer.transform
@@ -231,7 +231,7 @@ final class UIViewFrameTests: XCTestCase {
         for point: CGPoint,
         in sourceView: UIView,
         convertedTo targetView: UIView,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         let actualValue = try targetView.untransformedConvert(point, from: sourceView)

--- a/ParalayoutTests/ViewDistributionBuilderTests.swift
+++ b/ParalayoutTests/ViewDistributionBuilderTests.swift
@@ -200,7 +200,7 @@ final class ViewDistributionBuilderTests: XCTestCase {
 }
 #endif
 
-extension ViewDistributionItem: Equatable {
+extension ViewDistributionItem: Swift.Equatable { // TODO: `@retroactive Equatable` once we drop Xcode 15 support.
     nonisolated
     public static func == (lhs: ViewDistributionItem, rhs: ViewDistributionItem) -> Bool {
         switch (lhs, rhs) {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To install Paralayout via [Swift Package Manager](https://swift.org/package-mana
 
 ```swift
 dependencies: [
-    .package(name: "Paralayout", url: "https://github.com/square/Paralayout.git", from: "1.0.0"),
+    .package(name: "Paralayout", url: "https://github.com/square/Paralayout.git", from: "2.0.0"),
 ]
 ```
 </details>
@@ -39,7 +39,7 @@ dependencies: [
 To install Paralayout via [Bazel](https://github.com/bazelbuild/bazel), add the following to your `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "paralayout", version = "1.0.0")
+bazel_dep(name = "paralayout", version = "2.0.0")
 ```
 </details>
 

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -47,14 +47,17 @@ enum TaskError: Error {
 
 enum Platform: String, CustomStringConvertible {
 	case iOS_17
+	case iOS_18
 	case iPadOS_17
 
 	var destination: String {
 		switch self {
 		case .iOS_17:
-			return "platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro"
+			"platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro"
+		case .iOS_18:
+			"platform=iOS Simulator,OS=18.0,name=iPhone 16 Pro"
 		case .iPadOS_17:
-			return "platform=iOS Simulator,OS=17.5,name=iPad (10th generation)"
+			"platform=iOS Simulator,OS=17.5,name=iPad (10th generation)"
 		}
 	}
 


### PR DESCRIPTION
We already support Swift 6!

This PR:
* Gets us supporting Swift 6, without breaking support for Xcode 15.
* Adds an Xcode 16, iOS 18 test to make sure actually build in Swift 6 language mode.
* Update README and Podspec to reference a v2 rather than a v1.

Whough we'll likely want to break Xcode 15 at some point, we'll want to update our screenshot tests when we do that and that's a bigger job. When we do that, we'll likely only test on Xcode 16.

I know we've been pushing towards a breaking change release. Time to commit.